### PR TITLE
trove client version fix

### DIFF
--- a/troveclient/client.py
+++ b/troveclient/client.py
@@ -55,7 +55,7 @@ class TroveClientMixin(object):
     def get_database_api_version_from_endpoint(self):
         magic_tuple = urlparse.urlsplit(self.management_url)
         scheme, netloc, path, query, frag = magic_tuple
-        v = path.split("/")[1]
+        v = path.split("/")[2]
         valid_versions = ['v1.0']
         if v not in valid_versions:
             msg = "Invalid client version '%s'. must be one of: %s" % (


### PR DESCRIPTION
when path split, it should compare to 2nd element, not 1st
[u'', u'trove', u'v1.0', u'9d34cbd3e99647059fae2cc0e2d98f07']
currently getting error "Invalid client version 'trove'. must be one of: v1.0"